### PR TITLE
Remove printing of found config file

### DIFF
--- a/syntax_checkers/sass/sasslint.vim
+++ b/syntax_checkers/sass/sasslint.vim
@@ -36,7 +36,6 @@ function! SyntaxCheckers_sass_sasslint_GetLocList() dict
         endif
     else
         let found_config = syntastic#util#findFileInParent(sass_lint_config_file, expand('%:p:h'))
-        echomsg found_config
 
         if found_config !=# ''
            let sass_lint_config = fnamemodify(found_config, ':p')


### PR DESCRIPTION
vim-sass-lint prints out the found config filename every time you run `:w`. To my knowledge no other Syntastic syntax checkers have this behaviour. I would propose to remove it so it doesn’t distract the user.